### PR TITLE
Fix setSceneRect type error for PyQt6

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -85,7 +85,8 @@ class ImageView(QtWidgets.QGraphicsView):
         pix = QtGui.QPixmap.fromImage(qimage)
         self.scene().clear()
         self._pix = self.scene().addPixmap(pix)
-        self.setSceneRect(pix.rect())
+        # PyQt6 expects a QRectF for setSceneRect; wrap the pixmap rect accordingly.
+        self.setSceneRect(QtCore.QRectF(pix.rect()))
         self.fitInView(self.sceneRect(), QtCore.Qt.AspectRatioMode.KeepAspectRatio)
 
     def resizeEvent(self, e):


### PR DESCRIPTION
## Summary
- wrap the pixmap rectangle in a QRectF before passing it to setSceneRect to satisfy PyQt6's expected type
- add an inline comment documenting the rationale for the conversion

## Testing
- python -m compileall gui.py

------
https://chatgpt.com/codex/tasks/task_b_68e434bdffbc832f985df082a2144b15