### PR TITLE
Handle missing drag-and-drop dependency gracefully

### DIFF
--- a/dependency_bootstrap.py
+++ b/dependency_bootstrap.py
@@ -34,7 +34,7 @@ REQUIRED_DEPENDENCIES: List[Dependency] = [
     Dependency("numpy", "numpy"),
     Dependency("PIL", "Pillow"),
     Dependency("customtkinter", "customtkinter"),
-    Dependency("tkinterdnd2", "tkinterdnd2"),
+    Dependency("tkinterdnd2", "tkinterdnd2", required=False),
     Dependency("cv2", "opencv-python"),
     Dependency("piexif", "piexif"),
     Dependency("skimage", "scikit-image"),


### PR DESCRIPTION
## Summary
- treat tkinterdnd2 as an optional dependency and fall back to manual file selection when drag-and-drop support is unavailable
- surface optional dependency warnings inside the GUI log so users understand reduced functionality
- adjust UI placeholders and tooltips to guide users when drag-and-drop cannot be used

## Testing
- python -m compileall main.py dependency_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_b_68e4462d3f28832f8b112b2a0d11d7b2