### PR TITLE
Improve dependency bootstrap messaging for proxy failures

### DIFF
--- a/dependency_bootstrap.py
+++ b/dependency_bootstrap.py
@@ -48,8 +48,9 @@ REQUIRED_DEPENDENCIES: List[Dependency] = [
 class DependencyInstallationError(RuntimeError):
     """Raised when automatic installation fails for any dependency."""
 
-    def __init__(self, messages: Iterable[str]) -> None:
+    def __init__(self, messages: Iterable[str], *, is_network_error: bool = False) -> None:
         self.messages: List[str] = list(messages)
+        self.is_network_error = is_network_error
         joined = "\n\n".join(self.messages)
         super().__init__(
             "One or more Python packages could not be installed automatically.\n"
@@ -62,13 +63,60 @@ def _is_module_available(import_name: str) -> bool:
     return importlib.util.find_spec(import_name) is not None
 
 
+def _normalize_pip_output(output: str) -> str:
+    """Collapse repeated pip warnings to keep error messages concise."""
+
+    lines: List[str] = []
+    seen: set[str] = set()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+    # Pip can be quite verbose when retries are involved; showing the first
+    # handful of unique lines keeps the error readable for GUI users.
+    return "\n".join(lines[:5])
+
+
+def _detect_connectivity_issue(details: str) -> str | None:
+    """Return a human readable description if pip failed due to networking."""
+
+    lowered = details.lower()
+    if "proxyerror" in lowered or "cannot connect to proxy" in lowered:
+        if "403" in lowered:
+            return "Access to PyPI was blocked by a proxy (HTTP 403)."
+        return "The configured network proxy blocked the connection to PyPI."
+    if "temporary failure in name resolution" in lowered or "name or service not known" in lowered:
+        return "DNS lookups for PyPI failed."
+    if "failed to establish a new connection" in lowered or "connection timed out" in lowered:
+        return "The connection to PyPI timed out."
+    if "ssl" in lowered and "certificate verify failed" in lowered:
+        return "TLS certificate verification failed when contacting PyPI."
+    if "ssl" in lowered and "handshake" in lowered:
+        return "The TLS handshake with PyPI could not be completed."
+    return None
+
+
 def _install_dependency(dep: Dependency) -> None:
     cmd = [sys.executable, "-m", "pip", "install", dep.package_name, *dep.extra_args]
     completed = subprocess.run(cmd, check=False, capture_output=True, text=True)
     if completed.returncode == 0:
         return
 
-    details = completed.stderr.strip() or completed.stdout.strip()
+    details_raw = completed.stderr.strip() or completed.stdout.strip()
+    details = _normalize_pip_output(details_raw)
+    connectivity_hint = _detect_connectivity_issue(details)
+    if connectivity_hint is not None:
+        message = (
+            f"• Unable to download '{dep.package_name}' from PyPI.\n"
+            f"  {connectivity_hint}\n"
+            "  Verify internet access or configure your proxy, then install the required packages manually."
+        )
+        raise DependencyInstallationError([message], is_network_error=True)
+
     message = (
         f"• Failed to install '{dep.package_name}'.\n"
         f"  Command: {' '.join(cmd)}\n"
@@ -88,6 +136,7 @@ def ensure_dependencies() -> None:
 
     failures: List[str] = []
     optional_failures: List[str] = []
+    network_failure = False
     for dep in missing:
         try:
             _install_dependency(dep)
@@ -95,10 +144,21 @@ def ensure_dependencies() -> None:
             messages = exc.messages if hasattr(exc, "messages") else [str(exc)]
             if dep.required:
                 failures.extend(messages)
+                if getattr(exc, "is_network_error", False):
+                    network_failure = True
+                    break
             else:
                 optional_failures.extend(messages)
 
     if failures:
+        if network_failure:
+            manual_cmd = "python -m pip install " + " ".join(
+                dep.package_name for dep in missing if dep.required
+            )
+            failures.append(
+                "Manual installation command once connectivity is restored:\n"
+                f"    {manual_cmd}"
+            )
         raise DependencyInstallationError(failures)
 
     if optional_failures:


### PR DESCRIPTION
## Summary
- detect connectivity/proxy failures while running the automatic dependency installer
- keep pip error output concise and stop after the first required dependency fails
- provide a manual installation command for required packages when networking is blocked

## Testing
- python main.py


------
https://chatgpt.com/codex/tasks/task_b_68e44a953a7c832fac94693c611ad186