### PR TITLE
Ensure optional thermal parsers auto-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ infrastructure owners.
 
 ## Installation
 
-Double-clicking ``main.py`` now bootstraps all required Python packages automatically using ``python -m pip``. A reliable internet connection is recommended the first time you run the program so that dependencies can be downloaded.
+Double-clicking ``main.py`` now bootstraps all required Python packages automatically using ``python -m pip``. This includes optional helpers such as ``flirimageextractor`` and the DJI Thermal SDK bindings (installed from GitHub). A reliable internet connection is recommended the first time you run the program so that dependencies can be downloaded.
 
 Managed environments can still install dependencies explicitly:
 

--- a/dependency_bootstrap.py
+++ b/dependency_bootstrap.py
@@ -38,6 +38,12 @@ REQUIRED_DEPENDENCIES: List[Dependency] = [
     Dependency("cv2", "opencv-python"),
     Dependency("piexif", "piexif"),
     Dependency("skimage", "scikit-image"),
+    Dependency("flirimageextractor", "flirimageextractor", required=False),
+    Dependency(
+        "thermal_parser",
+        "dji-thermal-sdk @ git+https://github.com/dji-sdk/DJI-thermal-sdk.git",
+        required=False,
+    ),
     # Optional quality-of-life extras. Installing them automatically keeps the
     # GUI consistent for first-time users but the application can run without
     # them if installation fails.


### PR DESCRIPTION
## Summary
- extend the dependency bootstrapper so flirimageextractor and the DJI Thermal SDK bindings are auto-installed when missing
- clarify the installation section of the README to mention the new automatic installs

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68e451518768832f960b0d09785194ff